### PR TITLE
Enable custom en/de-coders

### DIFF
--- a/src/main/scala/com/softwaremill/react/kafka/KafkaActorSubscriber.scala
+++ b/src/main/scala/com/softwaremill/react/kafka/KafkaActorSubscriber.scala
@@ -2,22 +2,23 @@ package com.softwaremill.react.kafka
 
 import akka.stream.actor.{ActorSubscriber, ActorSubscriberMessage, WatermarkRequestStrategy}
 import kafka.producer.KafkaProducer
+import kafka.serializer.{Encoder, Decoder}
 
-private[kafka] class KafkaActorSubscriber(val producer: KafkaProducer) extends ActorSubscriber {
+private[kafka] class KafkaActorSubscriber[T](val producer: KafkaProducer, val encoder: Encoder[T]) extends ActorSubscriber {
 
   protected def requestStrategy = WatermarkRequestStrategy(10)
 
   def receive = {
     case ActorSubscriberMessage.OnNext(element) =>
-      processElement(element.asInstanceOf[String])
+      processElement(element.asInstanceOf[T])
     case ActorSubscriberMessage.OnError(ex) =>
       handleError(ex)
     case ActorSubscriberMessage.OnComplete =>
       streamFinished()
   }
 
-  private def processElement(element: String) = {
-    producer.send(element)
+  private def processElement(element: T) = {
+    producer.send(encoder.toBytes(element), None)
   }
 
   private def handleError(ex: Throwable) = {

--- a/src/main/scala/kafka/producer/KafkaProducer.scala
+++ b/src/main/scala/kafka/producer/KafkaProducer.scala
@@ -82,11 +82,11 @@ case class KafkaProducer(
     }
   }
 
-  def send(message: String, partition: String = null): Unit = send(message.getBytes("UTF8"), if (partition == null) null else partition.getBytes("UTF8"))
+  def send(message: String, partition: String = null): Unit = send(message.getBytes("UTF8"), Option(partition).map(_.getBytes("UTF8")))
 
-  def send(message: Array[Byte], partition: Array[Byte]): Unit = {
+  def send(message: Array[Byte], partition: Option[Array[Byte]]): Unit = {
     try {
-      producer.send(kafkaMesssage(message, partition))
+      producer.send(kafkaMesssage(message, partition.getOrElse(null)))
     } catch {
       case e: Exception =>
         e.printStackTrace()

--- a/src/test/scala/com/softwaremill/react/kafka/ReactiveKafkaPublisherSpec.scala
+++ b/src/test/scala/com/softwaremill/react/kafka/ReactiveKafkaPublisherSpec.scala
@@ -2,6 +2,7 @@ package com.softwaremill.react.kafka
 
 import java.util.UUID
 
+import kafka.serializer.StringDecoder
 import ly.stealth.testing.BaseSpec
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.reactivestreams.tck.{PublisherVerification, TestEnvironment}
@@ -36,7 +37,7 @@ class ReactiveKafkaPublisherSpec(defaultTimeout: FiniteDuration)
     (1L to realSize) foreach { number =>
       lowLevelProducer.send(record)
     }
-    kafka.consume(topic, group)
+    kafka.consume(topic, group, new StringDecoder())
   }
 
   override def createFailedPublisher(): Publisher[String] = {

--- a/src/test/scala/com/softwaremill/react/kafka/ReactiveKafkaSubscriberBlackboxSpec.scala
+++ b/src/test/scala/com/softwaremill/react/kafka/ReactiveKafkaSubscriberBlackboxSpec.scala
@@ -3,6 +3,7 @@ package com.softwaremill.react.kafka
 import java.util.UUID
 
 import akka.stream.scaladsl.{Sink, Source}
+import kafka.serializer.StringEncoder
 import org.reactivestreams.tck.{SubscriberBlackboxVerification, TestEnvironment}
 import org.reactivestreams.{Publisher, Subscriber}
 import org.scalatest.testng.TestNGSuiteLike
@@ -18,7 +19,7 @@ class ReactiveKafkaSubscriberBlackboxSpec(defaultTimeout: FiniteDuration)
 
   override def createSubscriber(): Subscriber[String] = {
     val topic = UUID.randomUUID().toString
-    kafka.publish(topic, "group")
+    kafka.publish(topic, "group", new StringEncoder())
   }
 
   def createHelperSource(elements: Long) : Source[String, _] = elements match {


### PR DESCRIPTION
Current implementation publishes and consumes only strings, added decoders/encoders to the list of params to allow other types