### PR TITLE
Java friendly wrapper for creating Consumer and Producer properties introduced in 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ val subscriber = kafka.publish(ProducerProperties(
 Source(publisher).map(_.toUpperCase).to(Sink(subscriber)).run()
 ```
 
+```Java
+private ActorSystem actorSystem = ActorSystem.create("ReactiveKafka")
+private String brokerList = "localhost:9092";
+private String zooKeeperHost = "localhost:2181";
+  
+private ReactiveKafka kafka = new ReactiveKafka(brokerList, zooKeeperHost)
+
+ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
+        .withStringDecoder(Optional.empty())
+        .withGroupId(groupName)
+        .withTopic(topic)
+        .<String>build();
+
+Publisher<String> publisher = kafka.consume(cp, actorSystem);
+        
+ProducerProperties<String> pp = new PropertiesBuilder.Producer()
+        .withStringEncoder(Optional.empty())
+        .withClientId(groupName)
+        .withTopic(topic)
+        .build();
+
+Subscriber<String> subscriber = kafka.publish(pp, actorSystem);
+
+Source(publisher).map((d) -> d.toUpperCase()).to(Sink(subscriber)).run()
+```
+
 Passing configuration properties to Kafka
 ----
 In order to set your own custom Kafka parameters, you can construct `ConsumerProperties` and `ProducerProperties` using

--- a/README.md
+++ b/README.md
@@ -59,16 +59,15 @@ String brokerList = "localhost:9092";
 
 ReactiveKafka kafka = new ReactiveKafka();
 ActorSystem system = ActorSystem.create("ReactiveKafka");
+ActorMaterializer materializer = ActorMaterializer.create(system);
 
 ConsumerProperties<String> cp =
-        new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId")
-                .withStringDecoder()
+        new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId", new StringDecoder(null))
                 .build();
 
 Publisher<String> publisher = kafka.consume(cp, system);
 
-ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId")
-        .withStringEncoder()
+ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId", new StringEncoder(null))
         .build();
 
 Subscriber<String> subscriber = kafka.publish(pp, system);

--- a/README.md
+++ b/README.md
@@ -58,20 +58,24 @@ private ActorSystem actorSystem = ActorSystem.create("ReactiveKafka")
 private String brokerList = "localhost:9092";
 private String zooKeeperHost = "localhost:2181";
   
-private ReactiveKafka kafka = new ReactiveKafka(brokerList, zooKeeperHost)
+private ReactiveKafka kafka = new ReactiveKafka()
 
 ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
-        .withStringDecoder(Optional.empty())
+        .withZooKeeperHost(zooKeeperHost)
+        .withBrokerList(brokerList)
         .withGroupId(groupName)
         .withTopic(topic)
+        .withStringDecoder()
         .<String>build();
 
 Publisher<String> publisher = kafka.consume(cp, actorSystem);
         
 ProducerProperties<String> pp = new PropertiesBuilder.Producer()
-        .withStringEncoder(Optional.empty())
+        .withZooKeeperHost(zooKeeperHost)
+        .withBrokerList(brokerList)
         .withClientId(groupName)
         .withTopic(topic)
+        .withStringEncoder()
         .build();
 
 Subscriber<String> subscriber = kafka.publish(pp, actorSystem);

--- a/README.md
+++ b/README.md
@@ -54,33 +54,34 @@ Source(publisher).map(_.toUpperCase).to(Sink(subscriber)).run()
 
 #### Java
 ```Java
-private ActorSystem actorSystem = ActorSystem.create("ReactiveKafka")
-private String brokerList = "localhost:9092";
-private String zooKeeperHost = "localhost:2181";
-  
-private ReactiveKafka kafka = new ReactiveKafka()
+String zooKeeperHost = "localhost:2181";
+String brokerList = "localhost:9092";
+
+ReactiveKafka kafka = new ReactiveKafka();
+ActorSystem system = ActorSystem.create("ReactiveKafka");
+ActorMaterializer materializer = ActorMaterializer.create(system);
 
 ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
         .withZooKeeperHost(zooKeeperHost)
         .withBrokerList(brokerList)
-        .withGroupId(groupName)
-        .withTopic(topic)
+        .withGroupId("groupName")
+        .withTopic("topic")
         .withStringDecoder()
         .build();
 
-Publisher<String> publisher = kafka.consume(cp, actorSystem);
-        
+Publisher<String> publisher = kafka.consume(cp, system);
+
 ProducerProperties<String> pp = new PropertiesBuilder.Producer()
         .withZooKeeperHost(zooKeeperHost)
         .withBrokerList(brokerList)
-        .withClientId(groupName)
-        .withTopic(topic)
+        .withClientId("groupName")
+        .withTopic("topic")
         .withStringEncoder()
         .build();
 
-Subscriber<String> subscriber = kafka.publish(pp, actorSystem);
+Subscriber<String> subscriber = kafka.publish(pp, system);
 
-Source(publisher).map((d) -> d.toUpperCase()).to(Sink(subscriber)).run()
+Source.from(publisher).map(String::toUpperCase).to(Sink.create(subscriber)).run(materializer);
 ```
 
 Passing configuration properties to Kafka

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tests require Apache Kafka and Zookeeper to be available on localhost:9092 and l
 Example usage
 ----
 
+#### Scala
 ```Scala
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -51,6 +52,7 @@ val subscriber = kafka.publish(ProducerProperties(
 Source(publisher).map(_.toUpperCase).to(Sink(subscriber)).run()
 ```
 
+#### Java
 ```Java
 private ActorSystem actorSystem = ActorSystem.create("ReactiveKafka")
 private String brokerList = "localhost:9092";

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
         .withGroupId(groupName)
         .withTopic(topic)
         .withStringDecoder()
-        .<String>build();
+        .build();
 
 Publisher<String> publisher = kafka.consume(cp, actorSystem);
         

--- a/README.md
+++ b/README.md
@@ -59,23 +59,15 @@ String brokerList = "localhost:9092";
 
 ReactiveKafka kafka = new ReactiveKafka();
 ActorSystem system = ActorSystem.create("ReactiveKafka");
-ActorMaterializer materializer = ActorMaterializer.create(system);
 
-ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
-        .withZooKeeperHost(zooKeeperHost)
-        .withBrokerList(brokerList)
-        .withGroupId("groupName")
-        .withTopic("topic")
-        .withStringDecoder()
-        .build();
+ConsumerProperties<String> cp =
+        new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId")
+                .withStringDecoder()
+                .build();
 
 Publisher<String> publisher = kafka.consume(cp, system);
 
-ProducerProperties<String> pp = new PropertiesBuilder.Producer()
-        .withZooKeeperHost(zooKeeperHost)
-        .withBrokerList(brokerList)
-        .withClientId("groupName")
-        .withTopic("topic")
+ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId")
         .withStringEncoder()
         .build();
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ libraryDependencies ++= Seq(
   "org.apache.kafka" %% "kafka" % "0.8.2.1",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "com.typesafe.akka" %% "akka-testkit" % "2.3.12" % "test",
-  "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test"
+  "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test",
+  "junit" % "junit" % "4.12" % "test"
 )
 
 publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,11 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "com.typesafe.akka" %% "akka-testkit" % "2.3.12" % "test",
   "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test",
+  "com.novocode" % "junit-interface" % "0.11" % "test",
   "junit" % "junit" % "4.12" % "test"
 )
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
 
 publishMavenStyle := true
 publishTo := {

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Builder class wrapping Consumer & Prooducer  properties creation in Java API.
+ * Builder class wrapping Consumer & Producer properties creation in Java API.
  */
 public class PropertiesBuilder {
 

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -148,7 +148,7 @@ public class PropertiesBuilder {
         /**
          * Create a ProducerProperties object
          *
-         * @param <C> the type of Producer to construct
+         * @param <P> the type of Producer to construct
          * @return a fully constructed ProducerProperties
          */
         public <P> ProducerProperties<P> build() {

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -64,7 +64,7 @@ public class PropertiesBuilder {
             return this;
         }
 
-        public <C> ConsumerProperties build() {
+        public <C> ConsumerProperties<C> build() {
             if (brokerList != null && zooKeeperHost != null) {
                 return ConsumerProperties.<C>apply(brokerList, zooKeeperHost, topic, groupId, decoder);
             }
@@ -131,7 +131,7 @@ public class PropertiesBuilder {
             return this;
         }
 
-        public <P> ProducerProperties build() {
+        public <P> ProducerProperties<P> build() {
             if (brokerList != null && zooKeeperHost != null) {
                 return ProducerProperties.<P>apply(brokerList, topic, clientId, encoder);
             }

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -1,7 +1,7 @@
 package com.softwaremill.react.kafka;
 
-import kafka.serializer.*;
-import kafka.utils.VerifiableProperties;
+import kafka.serializer.Decoder;
+import kafka.serializer.Encoder;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.HashMap;
 
@@ -59,25 +59,10 @@ public class PropertiesBuilder {
         private String groupId;
         private scala.collection.immutable.Map<String, String> consumerParams = new HashMap<>();
 
-        public Consumer(String zooKeeperHost, String brokerList, String topic, String groupId) {
+        public Consumer(String zooKeeperHost, String brokerList, String topic, String groupId, Decoder decoder) {
             super(zooKeeperHost, brokerList, topic);
-            this.decoder = new DefaultDecoder(null);
+            this.decoder = decoder;
             this.groupId = groupId;
-        }
-
-        public Consumer withStringDecoder(VerifiableProperties props) {
-            this.decoder = new StringDecoder(props);
-            return this;
-        }
-
-        public Consumer withStringDecoder() {
-            this.decoder = new StringDecoder(null);
-            return this;
-        }
-
-        public Consumer withDefaultDecoder(VerifiableProperties props) {
-            this.decoder = new DefaultDecoder(props);
-            return this;
         }
 
         public Consumer withParams(Map<String, String> params) {
@@ -109,35 +94,10 @@ public class PropertiesBuilder {
         private Encoder encoder;
         private scala.collection.immutable.Map<String, String> producerParams = new HashMap<>();
 
-        public Producer(String brokerList, String zooKeeperHost, String topic, String clientId) {
+        public Producer(String brokerList, String zooKeeperHost, String topic, String clientId, Encoder encoder) {
             super(brokerList, zooKeeperHost, topic);
             this.clientId = clientId;
-            this.encoder = new DefaultEncoder(null);
-        }
-
-        public Producer withStringEncoder(VerifiableProperties props) {
-            this.encoder = new StringEncoder(props);
-            return this;
-        }
-
-        public Producer withStringEncoder() {
-            this.encoder = new StringEncoder(null);
-            return this;
-        }
-
-        public Producer withDefaultEncoder(VerifiableProperties props) {
-            this.encoder = new DefaultEncoder(props);
-            return this;
-        }
-
-        public Producer withNullEncoder() {
-            this.encoder = new NullEncoder(null);
-            return this;
-        }
-
-        public Producer withNullEncoder(VerifiableProperties props) {
-            this.encoder = new NullEncoder(props);
-            return this;
+            this.encoder = encoder;
         }
 
         public Producer withParams(Map<String, String> params) {

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -79,7 +79,7 @@ public class PropertiesBuilder {
     public static class Producer {
 
         private String topic;
-        private String groupId;
+        private String clientId;
         private Encoder encoder;
         private String brokerList;
         private String zooKeeperHost;
@@ -90,8 +90,8 @@ public class PropertiesBuilder {
             return this;
         }
 
-        public Producer withGroupId(String groupId) {
-            this.groupId = groupId;
+        public Producer withClientId(String clientId) {
+            this.clientId = clientId;
             return this;
         }
 
@@ -133,9 +133,9 @@ public class PropertiesBuilder {
 
         public <P> ProducerProperties build() {
             if (brokerList != null && zooKeeperHost != null) {
-                return ProducerProperties.<P>apply(brokerList, topic, groupId, encoder);
+                return ProducerProperties.<P>apply(brokerList, topic, clientId, encoder);
             }
-            return ProducerProperties.<P>apply(producerParams, topic, groupId, encoder, null);
+            return ProducerProperties.<P>apply(producerParams, topic, clientId, encoder, null);
 
         }
 

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -6,7 +6,6 @@ import scala.collection.JavaConverters;
 import scala.collection.immutable.HashMap;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Builder class wrapping Consumer & Producer properties creation in Java API.
@@ -45,17 +44,23 @@ public class PropertiesBuilder {
             return this;
         }
 
-        public Consumer withStringDecoder(Optional<VerifiableProperties> props) {
-            this.decoder = props.isPresent()
-                    ? new StringDecoder(props.get())
-                    : new StringDecoder(null);
+        public Consumer withStringDecoder(VerifiableProperties props) {
+            this.decoder = new StringDecoder(props);
             return this;
         }
 
-        public Consumer withDefaultDecoder(Optional<VerifiableProperties> props) {
-            this.decoder = props.isPresent()
-                    ? new DefaultDecoder(props.get())
-                    : new DefaultDecoder(null);
+        public Consumer withStringDecoder() {
+            this.decoder = new StringDecoder(null);
+            return this;
+        }
+
+        public Consumer withDefaultDecoder(VerifiableProperties props) {
+            this.decoder = new DefaultDecoder(props);
+            return this;
+        }
+
+        public Consumer withDefaultDecoder() {
+            this.decoder = new DefaultDecoder(null);
             return this;
         }
 
@@ -105,24 +110,33 @@ public class PropertiesBuilder {
             return this;
         }
 
-        public Producer withStringEncoder(Optional<VerifiableProperties> props) {
-            this.encoder = props.isPresent()
-                    ? new StringEncoder(props.get())
-                    : new StringEncoder(null);
+        public Producer withStringEncoder(VerifiableProperties props) {
+            this.encoder = new StringEncoder(props);
             return this;
         }
 
-        public Producer withDefaultEncoder(Optional<VerifiableProperties> props) {
-            this.encoder = props.isPresent()
-                    ? new DefaultEncoder(props.get())
-                    : new DefaultEncoder(null);
+        public Producer withStringEncoder() {
+            this.encoder = new StringEncoder(null);
             return this;
         }
 
-        public Producer withNullEncoder(Optional<VerifiableProperties> props) {
-            this.encoder = props.isPresent()
-                    ? new NullEncoder(props.get())
-                    : new NullEncoder(null);
+        public Producer withDefaultEncoder() {
+            this.encoder = new DefaultEncoder(null);
+            return this;
+        }
+
+        public Producer withDefaultEncoder(VerifiableProperties props) {
+            this.encoder = new DefaultEncoder(props);
+            return this;
+        }
+
+        public Producer withNullEncoder() {
+            this.encoder = new NullEncoder(null);
+            return this;
+        }
+
+        public Producer withNullEncoder(VerifiableProperties props) {
+            this.encoder = new NullEncoder(props);
             return this;
         }
 

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -1,0 +1,144 @@
+package com.softwaremill.react.kafka;
+
+import kafka.serializer.*;
+import kafka.utils.VerifiableProperties;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.HashMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Builder class wrapping Consumer & Prooducer  properties creation in Java API.
+ */
+public class PropertiesBuilder {
+
+    /**
+     * The Consumer Builder
+     */
+    public static class Consumer {
+
+        private String topic;
+        private String groupId;
+        private Decoder decoder;
+        private String brokerList;
+        private String zooKeeperHost;
+        private scala.collection.immutable.Map<String, String> consumerParams = new HashMap<>();
+
+        public Consumer withTopic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Consumer withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        public Consumer withBrokerList(String brokerList) {
+            this.brokerList = brokerList;
+            return this;
+        }
+
+        public Consumer withZooKeeperHost(String zooKeeperHost) {
+            this.zooKeeperHost = zooKeeperHost;
+            return this;
+        }
+
+        public Consumer withStringDecoder(Optional<VerifiableProperties> props) {
+            this.decoder = props.isPresent()
+                    ? new StringDecoder(props.get())
+                    : new StringDecoder(null);
+            return this;
+        }
+
+        public Consumer withDefaultDecoder(Optional<VerifiableProperties> props) {
+            this.decoder = props.isPresent()
+                    ? new DefaultDecoder(props.get())
+                    : new DefaultDecoder(null);
+            return this;
+        }
+
+        public Consumer withParams(Map<String, String> params) {
+            this.consumerParams = new HashMap<String, String>().$plus$plus(JavaConverters.mapAsScalaMapConverter(params).asScala());
+            return this;
+        }
+
+        public <C> ConsumerProperties build() {
+            if (brokerList != null && zooKeeperHost != null) {
+                return ConsumerProperties.<C>apply(brokerList, zooKeeperHost, topic, groupId, decoder);
+            }
+            return ConsumerProperties.<C>apply(consumerParams, topic, groupId, decoder);
+        }
+
+    }
+
+    /**
+     * The Producer Builder
+     */
+    public static class Producer {
+
+        private String topic;
+        private String groupId;
+        private Encoder encoder;
+        private String brokerList;
+        private String zooKeeperHost;
+        private scala.collection.immutable.Map<String, String> producerParams = new HashMap<>();
+
+        public Producer withTopic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Producer withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        public Producer withBrokerList(String brokerList) {
+            this.brokerList = brokerList;
+            return this;
+        }
+
+        public Producer withZooKeeperHost(String zooKeeperHost) {
+            this.zooKeeperHost = zooKeeperHost;
+            return this;
+        }
+
+        public Producer withStringEncoder(Optional<VerifiableProperties> props) {
+            this.encoder = props.isPresent()
+                    ? new StringEncoder(props.get())
+                    : new StringEncoder(null);
+            return this;
+        }
+
+        public Producer withDefaultEncoder(Optional<VerifiableProperties> props) {
+            this.encoder = props.isPresent()
+                    ? new DefaultEncoder(props.get())
+                    : new DefaultEncoder(null);
+            return this;
+        }
+
+        public Producer withNullEncoder(Optional<VerifiableProperties> props) {
+            this.encoder = props.isPresent()
+                    ? new NullEncoder(props.get())
+                    : new NullEncoder(null);
+            return this;
+        }
+
+        public Producer withParams(Map<String, String> params) {
+            this.producerParams = new HashMap<String, String>().$plus$plus(JavaConverters.mapAsScalaMapConverter(params).asScala());
+            return this;
+        }
+
+        public <P> ProducerProperties build() {
+            if (brokerList != null && zooKeeperHost != null) {
+                return ProducerProperties.<P>apply(brokerList, topic, groupId, encoder);
+            }
+            return ProducerProperties.<P>apply(producerParams, topic, groupId, encoder, null);
+
+        }
+
+    }
+
+}

--- a/src/main/scala/com/softwaremill/react/kafka/ReactiveKafka.scala
+++ b/src/main/scala/com/softwaremill/react/kafka/ReactiveKafka.scala
@@ -14,7 +14,7 @@ class ReactiveKafka(val host: String = "", val zooKeeperHost: String = "") {
    * Constructor without default args
    */
   def this() = {
-    this("","")
+    this("", "")
   }
 
   @deprecated("Use ProducerProps", "0.7.0")

--- a/src/main/scala/com/softwaremill/react/kafka/ReactiveKafka.scala
+++ b/src/main/scala/com/softwaremill/react/kafka/ReactiveKafka.scala
@@ -10,6 +10,13 @@ import org.reactivestreams.{Publisher, Subscriber}
 
 class ReactiveKafka(val host: String = "", val zooKeeperHost: String = "") {
 
+  /**
+   * Constructor without default args
+   */
+  def this() = {
+    this("","")
+  }
+
   @deprecated("Use ProducerProps", "0.7.0")
   def publish[T](
     topic: String,

--- a/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
@@ -31,21 +31,14 @@ public class JavaConstructorTest {
         ActorSystem system = ActorSystem.create("ReactiveKafka");
         ActorMaterializer materializer = ActorMaterializer.create(system);
 
-        ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
-                .withZooKeeperHost(zooKeeperHost)
-                .withBrokerList(brokerList)
-                .withGroupId("groupName")
-                .withTopic("topic")
-                .withStringDecoder()
-                .build();
+        ConsumerProperties<String> cp =
+                new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId")
+                        .withStringDecoder()
+                        .build();
 
         Publisher<String> publisher = kafka.consume(cp, system);
 
-        ProducerProperties<String> pp = new PropertiesBuilder.Producer()
-                .withZooKeeperHost(zooKeeperHost)
-                .withBrokerList(brokerList)
-                .withClientId("groupName")
-                .withTopic("topic")
+        ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId")
                 .withStringEncoder()
                 .build();
 

--- a/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
@@ -1,0 +1,16 @@
+package com.softwaremill.react.kafka;
+
+
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.assertNotNull;
+
+public class JavaConstructorTest {
+
+    @Test
+    public void canConstructReactiveKafkaWithoutDefaultArgs() {
+        final ReactiveKafka reactiveKafka = new ReactiveKafka();
+        assertNotNull(reactiveKafka);
+    }
+
+}

--- a/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
@@ -5,6 +5,8 @@ import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import kafka.serializer.StringDecoder;
+import kafka.serializer.StringEncoder;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
@@ -15,14 +17,14 @@ import static junit.framework.Assert.assertNotNull;
 public class JavaConstructorTest {
 
     @Test
-    public void canConstructReactiveKafkaWithoutDefaultArgs() {
+    public void javaCanConstructReactiveKafkaWithoutDefaultArgs() {
         final ReactiveKafka reactiveKafka = new ReactiveKafka();
         assertNotNull(reactiveKafka);
     }
 
     @Test
     @Ignore("Disabled as we need a kafka endpoint - this example is displayed on the README")
-    public void canConstructKafkaConsumerAndProducerInJava() {
+    public void javaCanConstructKafkaConsumerAndProducerInJava() {
 
         String zooKeeperHost = "localhost:2181";
         String brokerList = "localhost:9092";
@@ -32,14 +34,12 @@ public class JavaConstructorTest {
         ActorMaterializer materializer = ActorMaterializer.create(system);
 
         ConsumerProperties<String> cp =
-                new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId")
-                        .withStringDecoder()
+                new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId", new StringDecoder(null))
                         .build();
 
         Publisher<String> publisher = kafka.consume(cp, system);
 
-        ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId")
-                .withStringEncoder()
+        ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId", new StringEncoder(null))
                 .build();
 
         Subscriber<String> subscriber = kafka.publish(pp, system);

--- a/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
@@ -1,7 +1,14 @@
 package com.softwaremill.react.kafka;
 
 
-import org.testng.annotations.Test;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
 import static junit.framework.Assert.assertNotNull;
 
@@ -11,6 +18,40 @@ public class JavaConstructorTest {
     public void canConstructReactiveKafkaWithoutDefaultArgs() {
         final ReactiveKafka reactiveKafka = new ReactiveKafka();
         assertNotNull(reactiveKafka);
+    }
+
+    @Test
+    @Ignore("Disabled as we need a kafka endpoint - this example is displayed on the README")
+    public void canConstructKafkaConsumerAndProducerInJava() {
+
+        String zooKeeperHost = "localhost:2181";
+        String brokerList = "localhost:9092";
+
+        ReactiveKafka kafka = new ReactiveKafka();
+        ActorSystem system = ActorSystem.create("ReactiveKafka");
+        ActorMaterializer materializer = ActorMaterializer.create(system);
+
+        ConsumerProperties<String> cp = new PropertiesBuilder.Consumer()
+                .withZooKeeperHost(zooKeeperHost)
+                .withBrokerList(brokerList)
+                .withGroupId("groupName")
+                .withTopic("topic")
+                .withStringDecoder()
+                .build();
+
+        Publisher<String> publisher = kafka.consume(cp, system);
+
+        ProducerProperties<String> pp = new PropertiesBuilder.Producer()
+                .withZooKeeperHost(zooKeeperHost)
+                .withBrokerList(brokerList)
+                .withClientId("groupName")
+                .withTopic("topic")
+                .withStringEncoder()
+                .build();
+
+        Subscriber<String> subscriber = kafka.publish(pp, system);
+
+        Source.from(publisher).map(String::toUpperCase).to(Sink.create(subscriber)).run(materializer);
     }
 
 }

--- a/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
@@ -5,7 +5,6 @@ import kafka.consumer.ConsumerConfig;
 import kafka.serializer.StringDecoder;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import static junit.framework.Assert.assertEquals;
@@ -26,7 +25,7 @@ public class JavaConsumerPropertiesTest {
                 .withBrokerList(brokerList)
                 .withGroupId(groupId)
                 .withTopic(topic)
-                .withStringDecoder(Optional.empty())
+                .withStringDecoder()
                 .build();
 
         final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
@@ -49,7 +48,7 @@ public class JavaConsumerPropertiesTest {
                 .withBrokerList(brokerList)
                 .withGroupId(groupId)
                 .withTopic(topic)
-                .withStringDecoder(Optional.empty())
+                .withStringDecoder()
                 .build()
                 .readFromEndOfStream()
                 .consumerTimeoutMs(1234)

--- a/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
@@ -1,0 +1,70 @@
+package com.softwaremill.react.kafka;
+
+
+import kafka.consumer.ConsumerConfig;
+import kafka.serializer.StringDecoder;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static junit.framework.Assert.assertEquals;
+
+public class JavaConsumerPropertiesTest {
+
+    private final String uuid = UUID.randomUUID().toString();
+    private final String brokerList = "localhost:9092";
+    private final String zooKeepHost = "localhost:2181";
+    private final String topic = uuid;
+    private final String groupId = uuid;
+
+    @Test
+    public void HandleBaseCase() {
+
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer()
+                .withZooKeeperHost(zooKeepHost)
+                .withBrokerList(brokerList)
+                .withGroupId(groupId)
+                .withTopic(topic)
+                .withStringDecoder(Optional.empty())
+                .build();
+
+        final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
+
+        assertEquals(consumerProperties.topic(), topic);
+        assertEquals(consumerProperties.groupId(), groupId);
+        assertEquals(consumerProperties.decoder().getClass().getSimpleName(), StringDecoder.class.getSimpleName());
+        assertEquals(consumerConfig.clientId(), groupId);
+        assertEquals(consumerConfig.autoOffsetReset(), "smallest");
+        assertEquals(consumerConfig.offsetsStorage(), "zookeeper");
+        assertEquals(consumerConfig.consumerTimeoutMs(), 1500);
+        assertEquals(consumerConfig.dualCommitEnabled(), false);
+    }
+
+    @Test
+    public void HandleKafkaStorage() {
+
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer()
+                .withZooKeeperHost(zooKeepHost)
+                .withBrokerList(brokerList)
+                .withGroupId(groupId)
+                .withTopic(topic)
+                .withStringDecoder(Optional.empty())
+                .build()
+                .readFromEndOfStream()
+                .consumerTimeoutMs(1234)
+                .kafkaOffsetsStorage(true);
+
+        final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
+
+        assertEquals(consumerProperties.topic(), topic);
+        assertEquals(consumerProperties.groupId(), groupId);
+        assertEquals(consumerProperties.decoder().getClass().getSimpleName(), StringDecoder.class.getSimpleName());
+        assertEquals(consumerConfig.clientId(), groupId);
+        assertEquals(consumerConfig.autoOffsetReset(), "largest");
+        assertEquals(consumerConfig.offsetsStorage(), "kafka");
+        assertEquals(consumerConfig.consumerTimeoutMs(), 1234);
+        assertEquals(consumerConfig.dualCommitEnabled(), true);
+    }
+
+}

--- a/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
@@ -20,11 +20,7 @@ public class JavaConsumerPropertiesTest {
     @Test
     public void HandleBaseCase() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer()
-                .withZooKeeperHost(zooKeepHost)
-                .withBrokerList(brokerList)
-                .withGroupId(groupId)
-                .withTopic(topic)
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId)
                 .withStringDecoder()
                 .build();
 
@@ -43,11 +39,7 @@ public class JavaConsumerPropertiesTest {
     @Test
     public void HandleKafkaStorage() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer()
-                .withZooKeeperHost(zooKeepHost)
-                .withBrokerList(brokerList)
-                .withGroupId(groupId)
-                .withTopic(topic)
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId)
                 .withStringDecoder()
                 .build()
                 .readFromEndOfStream()

--- a/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
@@ -18,10 +18,9 @@ public class JavaConsumerPropertiesTest {
     private final String groupId = uuid;
 
     @Test
-    public void HandleBaseCase() {
+    public void javaHandleBaseCase() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId)
-                .withStringDecoder()
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId, new StringDecoder(null))
                 .build();
 
         final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
@@ -37,10 +36,9 @@ public class JavaConsumerPropertiesTest {
     }
 
     @Test
-    public void HandleKafkaStorage() {
+    public void javaHandleKafkaStorage() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId)
-                .withStringDecoder()
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId, new StringDecoder(null))
                 .build()
                 .readFromEndOfStream()
                 .consumerTimeoutMs(1234)

--- a/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
@@ -1,5 +1,69 @@
 package com.softwaremill.react.kafka;
 
 
+import kafka.producer.ProducerConfig;
+import kafka.serializer.StringEncoder;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static junit.framework.Assert.assertEquals;
+
 public class JavaProducerPropertiesTest {
+
+
+    private final String uuid = UUID.randomUUID().toString();
+    private final String brokerList = "localhost:9092";
+    private final String zooKeepHost = "localhost:2181";
+    private final String topic = uuid;
+    private final String groupId = uuid;
+
+    @Test
+    public void HandleBaseCase() {
+
+        final ProducerProperties producerProperties = new PropertiesBuilder.Producer()
+                .withZooKeeperHost(zooKeepHost)
+                .withBrokerList(brokerList)
+                .withClientId(groupId)
+                .withTopic(topic)
+                .withStringEncoder(Optional.empty())
+                .build();
+
+        final ProducerConfig producerConfig = producerProperties.toProducerConfig();
+
+        assertEquals(producerProperties.topic(), topic);
+        assertEquals(producerProperties.encoder().getClass().getSimpleName(), StringEncoder.class.getSimpleName());
+        assertEquals(producerConfig.clientId(), groupId);
+        assertEquals(producerConfig.messageSendMaxRetries(), 3);
+        assertEquals(producerConfig.requestRequiredAcks(), -1);
+        assertEquals(producerConfig.batchNumMessages(), 200); // kafka defaults
+        assertEquals(producerConfig.queueBufferingMaxMs(), 5000); // kafka defaults
+    }
+
+    @Test
+    public void HandleAsyncSnappyCase() {
+
+        final ProducerProperties producerProperties = new PropertiesBuilder.Producer()
+                .withZooKeeperHost(zooKeepHost)
+                .withBrokerList(brokerList)
+                .withClientId(groupId)
+                .withTopic(topic)
+                .withStringEncoder(Optional.empty())
+                .build()
+                .asynchronous(123, 456)
+                .useSnappyCompression();
+
+        final ProducerConfig producerConfig = producerProperties.toProducerConfig();
+
+        assertEquals(producerProperties.topic(), topic);
+        assertEquals(producerProperties.clientId(), groupId);
+        assertEquals(producerProperties.encoder().getClass().getSimpleName(), StringEncoder.class.getSimpleName());
+        assertEquals(producerConfig.clientId(), groupId);
+        assertEquals(producerConfig.messageSendMaxRetries(), 3);
+        assertEquals(producerConfig.requestRequiredAcks(), -1);
+        assertEquals(producerConfig.batchNumMessages(), 123);
+        assertEquals(producerConfig.queueBufferingMaxMs(), 456);
+    }
+
 }

--- a/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
@@ -19,12 +19,10 @@ public class JavaProducerPropertiesTest {
     private final String groupId = uuid;
 
     @Test
-    public void HandleBaseCase() {
+    public void javaHandleBaseCase() {
 
         final ProducerProperties producerProperties =
-                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId)
-                        .withStringEncoder()
-                        .build();
+                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId, new StringEncoder(null)).build();
 
         final ProducerConfig producerConfig = producerProperties.toProducerConfig();
 
@@ -38,11 +36,10 @@ public class JavaProducerPropertiesTest {
     }
 
     @Test
-    public void HandleAsyncSnappyCase() {
+    public void javaHandleAsyncSnappyCase() {
 
         final ProducerProperties producerProperties =
-                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId)
-                        .withStringEncoder()
+                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId, new StringEncoder(null))
                         .build()
                         .asynchronous(123, 456)
                         .useSnappyCompression();

--- a/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
@@ -5,7 +5,6 @@ import kafka.producer.ProducerConfig;
 import kafka.serializer.StringEncoder;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import static junit.framework.Assert.assertEquals;
@@ -22,13 +21,10 @@ public class JavaProducerPropertiesTest {
     @Test
     public void HandleBaseCase() {
 
-        final ProducerProperties producerProperties = new PropertiesBuilder.Producer()
-                .withZooKeeperHost(zooKeepHost)
-                .withBrokerList(brokerList)
-                .withClientId(groupId)
-                .withTopic(topic)
-                .withStringEncoder(Optional.empty())
-                .build();
+        final ProducerProperties producerProperties =
+                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId)
+                        .withStringEncoder()
+                        .build();
 
         final ProducerConfig producerConfig = producerProperties.toProducerConfig();
 
@@ -44,15 +40,12 @@ public class JavaProducerPropertiesTest {
     @Test
     public void HandleAsyncSnappyCase() {
 
-        final ProducerProperties producerProperties = new PropertiesBuilder.Producer()
-                .withZooKeeperHost(zooKeepHost)
-                .withBrokerList(brokerList)
-                .withClientId(groupId)
-                .withTopic(topic)
-                .withStringEncoder(Optional.empty())
-                .build()
-                .asynchronous(123, 456)
-                .useSnappyCompression();
+        final ProducerProperties producerProperties =
+                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId)
+                        .withStringEncoder()
+                        .build()
+                        .asynchronous(123, 456)
+                        .useSnappyCompression();
 
         final ProducerConfig producerConfig = producerProperties.toProducerConfig();
 

--- a/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
@@ -1,0 +1,5 @@
+package com.softwaremill.react.kafka;
+
+
+public class JavaProducerPropertiesTest {
+}


### PR DESCRIPTION
I have the need to use `reactive-kafka` in a Java 8 project and would like to add a Java friendly wrapper to create Consumer and Producer properties recently added in version `0.7.0`.

The builders are basic but should provider a cleaner more Java friendly API for constructing both a Consumer and Producer configuration classes. Thoughts?

* [x] Create `Producer` builder
* [x] Create `Consumer` builder
* [x] Remove need to provide default args from Java
* [x] Create tests for both builders
* [x] Update docs
* [x] Ready for review/merge
 