### PR TITLE
fixed issue #33 - Java API connection problems caused by mismatched param ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,19 @@ ReactiveKafka kafka = new ReactiveKafka();
 ActorSystem system = ActorSystem.create("ReactiveKafka");
 ActorMaterializer materializer = ActorMaterializer.create(system);
 
-ConsumerProperties<String> cp =
-        new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId", new StringDecoder(null))
-                .build();
+ConsumerProperties<Byte[], String> cp =
+   new PropertiesBuilder.Consumer(brokerList, zooKeeperHost, "topic", "groupId", new StringDecoder(null))
+      .build();
 
-Publisher<String> publisher = kafka.consume(cp, system);
+Publisher<KeyValueKafkaMessage<Byte[], String>> publisher = kafka.consume(cp, system);
 
-ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId", new StringEncoder(null))
-        .build();
+ProducerProperties<String> pp = 
+   new PropertiesBuilder.Producer(brokerList, zooKeeperHost, "topic", "clientId", new StringEncoder(null))
+      .build();
 
 Subscriber<String> subscriber = kafka.publish(pp, system);
 
-Source.from(publisher).map(String::toUpperCase).to(Sink.create(subscriber)).run(materializer);
+Source.from(publisher).map(KeyValueKafkaMessage::msg).to(Sink.create(subscriber)).run(materializer);
 ```
 
 Passing configuration properties to Kafka

--- a/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
+++ b/src/main/java/com/softwaremill/react/kafka/PropertiesBuilder.java
@@ -61,8 +61,8 @@ public class PropertiesBuilder {
         private String groupId;
         private scala.collection.immutable.Map<String, String> consumerParams = new HashMap<>();
 
-        public Consumer(String zooKeeperHost, String brokerList, String topic, String groupId, Decoder decoder) {
-            super(zooKeeperHost, brokerList, topic);
+        public Consumer(String brokerList, String zooKeeperHost, String topic, String groupId, Decoder decoder) {
+            super(brokerList, zooKeeperHost, topic);
             this.decoder = decoder;
             this.groupId = groupId;
         }

--- a/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConstructorTest.java
@@ -34,12 +34,12 @@ public class JavaConstructorTest {
         ActorMaterializer materializer = ActorMaterializer.create(system);
 
         ConsumerProperties<Byte[], String> cp =
-                new PropertiesBuilder.Consumer(zooKeeperHost, brokerList, "topic", "groupId", new StringDecoder(null))
+                new PropertiesBuilder.Consumer(brokerList, zooKeeperHost, "topic", "groupId", new StringDecoder(null))
                         .build();
 
         Publisher<KeyValueKafkaMessage<Byte[], String>> publisher = kafka.consume(cp, system);
 
-        ProducerProperties<String> pp = new PropertiesBuilder.Producer(zooKeeperHost, brokerList, "topic", "clientId", new StringEncoder(null))
+        ProducerProperties<String> pp = new PropertiesBuilder.Producer(brokerList, zooKeeperHost, "topic", "clientId", new StringEncoder(null))
                 .build();
 
         Subscriber<String> subscriber = kafka.publish(pp, system);

--- a/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaConsumerPropertiesTest.java
@@ -20,11 +20,15 @@ public class JavaConsumerPropertiesTest {
     @Test
     public void javaHandleBaseCase() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId, new StringDecoder(null))
-                .build();
+        final PropertiesBuilder.Consumer propsBuilder = new PropertiesBuilder.Consumer(brokerList, zooKeepHost, topic, groupId, new StringDecoder(null));
+        assertEquals(propsBuilder.getBrokerList(), brokerList);
+        assertEquals(propsBuilder.getZooKeeperHost(), zooKeepHost);
+
+        final ConsumerProperties consumerProperties = propsBuilder.build();
 
         final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
 
+        assertEquals(consumerProperties.zookeeperConnect().get(), zooKeepHost);
         assertEquals(consumerProperties.topic(), topic);
         assertEquals(consumerProperties.groupId(), groupId);
         assertEquals(consumerProperties.decoder().getClass().getSimpleName(), StringDecoder.class.getSimpleName());
@@ -38,7 +42,7 @@ public class JavaConsumerPropertiesTest {
     @Test
     public void javaHandleKafkaStorage() {
 
-        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(zooKeepHost, brokerList, topic, groupId, new StringDecoder(null))
+        final ConsumerProperties consumerProperties = new PropertiesBuilder.Consumer(brokerList, zooKeepHost, topic, groupId, new StringDecoder(null))
                 .build()
                 .readFromEndOfStream()
                 .consumerTimeoutMs(1234)
@@ -46,6 +50,7 @@ public class JavaConsumerPropertiesTest {
 
         final ConsumerConfig consumerConfig = consumerProperties.toConsumerConfig();
 
+        assertEquals(consumerProperties.zookeeperConnect().get(), zooKeepHost);
         assertEquals(consumerProperties.topic(), topic);
         assertEquals(consumerProperties.groupId(), groupId);
         assertEquals(consumerProperties.decoder().getClass().getSimpleName(), StringDecoder.class.getSimpleName());

--- a/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
+++ b/src/test/java/com/softwaremill/react/kafka/JavaProducerPropertiesTest.java
@@ -21,8 +21,11 @@ public class JavaProducerPropertiesTest {
     @Test
     public void javaHandleBaseCase() {
 
-        final ProducerProperties producerProperties =
-                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId, new StringEncoder(null)).build();
+        final PropertiesBuilder.Producer propsBuilder = new PropertiesBuilder.Producer(brokerList, zooKeepHost, topic, groupId, new StringEncoder(null));
+        assertEquals(propsBuilder.getBrokerList(), brokerList);
+        assertEquals(propsBuilder.getZooKeeperHost(), zooKeepHost);
+
+        final ProducerProperties producerProperties = propsBuilder.build();
 
         final ProducerConfig producerConfig = producerProperties.toProducerConfig();
 
@@ -39,7 +42,7 @@ public class JavaProducerPropertiesTest {
     public void javaHandleAsyncSnappyCase() {
 
         final ProducerProperties producerProperties =
-                new PropertiesBuilder.Producer(zooKeepHost, brokerList, topic, groupId, new StringEncoder(null))
+                new PropertiesBuilder.Producer(brokerList, zooKeepHost, topic, groupId, new StringEncoder(null))
                         .build()
                         .asynchronous(123, 456)
                         .useSnappyCompression();


### PR DESCRIPTION
This fixes issue: https://github.com/softwaremill/reactive-kafka/issues/33

- [x] Re-ordered params in the `PropertiesBuilder.java` to be consistent throughout.
- [x] Updated tests to prove broker and zookeeper are set correctly
- [x] Updated `readme` according to recent changes