### PR TITLE
Add imports to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import kafka.serializer.{StringDecoder, StringEncoder}
+import org.reactivestreams.{Publisher, Subscriber}
 import com.softwaremill.react.kafka.{ReactiveKafka, ProducerProperties, ConsumerProperties}
 
 implicit val actorSystem = ActorSystem("ReactiveKafka")


### PR DESCRIPTION
Publisher and Subscriber should be imported for the example to be slightly more copy-and-paste-able.