### PR TITLE
Fix off-by-one error (issue #53)

### DIFF
--- a/core/src/main/scala/com/softwaremill/react/kafka/commit/OffsetMap.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/commit/OffsetMap.scala
@@ -20,6 +20,8 @@ case class OffsetMap(map: Offsets = Map.empty) {
 
   def toCommitRequestInfo = {
     val now = System.currentTimeMillis()
+    // Kafka expects the offset of the first unfetched message, and we have the
+    // offset of the last fetched message
     map.mapValues(offset => OffsetAndMetadata(offset + 1, timestamp = now))
   }
 }


### PR DESCRIPTION
Reset scheduled flush as first step when flushing
Keep offset of last fetched message in committer: adapt fetch request response to get the expected offset