### PR TITLE
Updating to latest Akka Stream 2.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scalariform.formatter.preferences.{SpacesAroundMultiImports, CompactContr
 name := "reactive-kafka"
 
 val akkaVersion = "2.3.14"
-val akkaStreamVersion = "2.0.1"
+val akkaStreamVersion = "2.0.3"
 val curatorVersion = "2.9.0"
 
 val kafka = "org.apache.kafka" %% "kafka" % "0.8.2.2" exclude("org.slf4j", "slf4j-log4j12") exclude("log4j", "log4j")


### PR DESCRIPTION
This change pulls in the latest _Akka Stream_ (2.0.3).

I've ran the using `sbt test` and got

```
[info] All tests passed.
[info] Passed: Total 118, Failed 0, Errors 0, Passed 117, Skipped 1, Ignored 96
[success] Total time: 54 s, completed Feb 4, 2016 6:56:52 PM
```