### PR TITLE
Uncommented the Graph sample

### DIFF
--- a/core/src/test/scala/examples/NewAPIExample.scala
+++ b/core/src/test/scala/examples/NewAPIExample.scala
@@ -13,8 +13,8 @@ object NewAPIExample {
 
   //--- Graph ---
   {
-    /* tbd. What's the 'provider' in the sample?
-    //
+    val provider: ConsumerProvider[Array[Byte],String] = ???
+
     val graph = GraphDSL.create(Consumer[Array[Byte], String](provider)) { implicit b => kafka =>
       import GraphDSL.Implicits._
       type In = ConsumerRecord[Array[Byte], String]
@@ -25,7 +25,6 @@ object NewAPIExample {
       kafka.confirmation ~> shutdownHandler
       ClosedShape
     }
-    */
   }
 
   //--- Consumer provider ---


### PR DESCRIPTION
In an earlier PR #85, I had brought these in to compile. One of them didn't - now it does.

This PR kind of fixes the earlier, but even having the code might be a temporary thing, since an actually runnable sample (the `DummyConsumer` and `DummyProducer`) are always better. But as long as these are mentioned in the docs, they can probably be in the code as well.