### PR TITLE
??? triggers dead-code warning, with 'sbt test' 

### DIFF
--- a/core/src/test/scala/examples/NewAPIExample.scala
+++ b/core/src/test/scala/examples/NewAPIExample.scala
@@ -13,7 +13,9 @@ object NewAPIExample {
 
   //--- Graph ---
   {
-    val provider: ConsumerProvider[Array[Byte],String] = ???
+  /* Disabled because '???' would give "dead code" error in 'sbt test'.
+   *
+    val provider: ConsumerProvider[Array[Byte], String] = ???
 
     val graph = GraphDSL.create(Consumer[Array[Byte], String](provider)) { implicit b => kafka =>
       import GraphDSL.Implicits._
@@ -25,6 +27,7 @@ object NewAPIExample {
       kafka.confirmation ~> shutdownHandler
       ClosedShape
     }
+  */
   }
 
   //--- Consumer provider ---


### PR DESCRIPTION
Hadn't noticed this in #87 - sorry.

With the code out of the comments, the use of `-Ywarn-dead-code` kicks in with `sbt test` (kind of surprising, I would suppose `???` not to be treated as dead code). Anyways, it may be best to do other stuff and keep the graph in comments.

Or remove the whole file, as unneeded?