### PR TITLE
brokerList -> bootstrapServers in the samples (README) where code wouldn't compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ implicit val materializer = ActorMaterializer()
 val kafka = new ReactiveKafka()
 // consumer
 val consumerProperties = ConsumerProperties(
-  brokerList = "localhost:9092",
+  bootstrapServers = "localhost:9092",
   topic = "lowercaseStrings",
   groupId = "groupName",
   valueDeserializer = new StringDeserializer()
@@ -159,7 +159,7 @@ val topLevelPublisherActor: ActorRef = kafka.consumerActor(consumerActorProps)
 
 // subscriber
 val producerProperties = ProducerProperties(
-  brokerList = "localhost:9092",
+  bootstrapServers = "localhost:9092",
   topic = "uppercaseStrings",
   new StringSerializer()
 )
@@ -231,7 +231,7 @@ implicit val materializer = ActorMaterializer()
 
 val kafka = new ReactiveKafka()
 val consumerProperties = ConsumerProperties(
-  brokerList = "localhost:9092",
+  bootstrapServers = "localhost:9092",
   topic = "lowercaseStrings",
   groupId = "groupName",
   valueDeserializer = new StringDeserializer())


### PR DESCRIPTION
It seems there's been a change of names from `brokerList` (which I personally find very nice) to `bootstrapServers` (which seems to be the Kafka property name). Currently, the code and comments have both.

The problem is that the three cases this PR targets wouldn't compile, if taken into code.

As a larger point, I feel having code samples in text in the README may be a bad idea. They don't get tested by test suites.